### PR TITLE
Allow specifying kickstarter file

### DIFF
--- a/httpd.sh
+++ b/httpd.sh
@@ -1,5 +1,13 @@
+KS=$1
+[[ -n "${KS}" ]] || KS=ks.cfg
+if [ ! -f "${KS}" ]
+then
+  echo "Kickstarter file ${KS} not found, aborting"
+  exit 1
+fi
+
 date=`date`
-size=`ls -l ks.cfg | awk '{ print $5 }'`
+size=`ls -l ${KS} | awk '{ print $5 }'`
 
 cat <<EOF
 HTTP/1.0 200 OK

--- a/setup
+++ b/setup
@@ -48,7 +48,7 @@ IP=`echo ${NATNET} | sed -nE 's/^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}).*/\1/p'`
 
 echo 'At the boot prompt, hit <TAB> and then type:'
 echo " ks=http://${IP}.3:8081"
-sh ./httpd.sh | nc -l 8081 >/dev/null
+sh ./httpd.sh $1 | nc -l 8081 >/dev/null
 
 echo "The box has accepted the kickstart file. It will now go through"
 echo "a lengthy install. When it is finished it will shutdown and you"


### PR DESCRIPTION
Passes parameter through from 'setup' as a parameter to 'httpd.sh'. Makes 'httpd.sh' default to 'ks.cfg' but allow a different file to be used.
